### PR TITLE
The module to unite debts was carried out

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -28,7 +28,7 @@ class DashboardController extends Controller
 
         $debtOverThreeYearsAll = Customer::select('customers.id', 'customers.name', 'customers.last_name')
             ->join('debts', 'customers.id', '=', 'debts.customer_id')
-            ->where('debts.status', '!=', 'paid') 
+            ->whereNotIn('debts.status', ['paid', 'united'])
             ->selectRaw(
                 'SUM(TIMESTAMPDIFF(MONTH, debts.start_date, debts.end_date) + IF(DAY(debts.end_date) >= DAY(debts.start_date), 1, 0)) as total_months'
             )
@@ -38,7 +38,7 @@ class DashboardController extends Controller
 
             $debtBetweenTwelveAndThirtySixMonthsAll = Customer::select('customers.id', 'customers.name', 'customers.last_name')
             ->join('debts', 'customers.id', '=', 'debts.customer_id')
-            ->where('debts.status', '!=', 'paid') 
+            ->whereNotIn('debts.status', ['paid', 'united'])
             ->selectRaw(
                 'SUM(TIMESTAMPDIFF(MONTH, debts.start_date, debts.end_date) + IF(DAY(debts.end_date) >= DAY(debts.start_date), 1, 0)) as total_months'
             )
@@ -48,7 +48,7 @@ class DashboardController extends Controller
         
             $debtBetweenOneAndElevenMonthsAll = Customer::select('customers.id', 'customers.name', 'customers.last_name')
                 ->join('debts', 'customers.id', '=', 'debts.customer_id')
-                ->where('debts.status', '!=', 'paid') 
+                ->whereNotIn('debts.status', ['paid', 'united'])
                 ->selectRaw(
                     'SUM(TIMESTAMPDIFF(MONTH, debts.start_date, debts.end_date) + IF(DAY(debts.end_date) >= DAY(debts.start_date), 1, 0)) as total_months'
                 )
@@ -105,7 +105,7 @@ class DashboardController extends Controller
     {
         $debtOverThreeYearsAll = Customer::select('customers.id', 'customers.name', 'customers.last_name')
             ->join('debts', 'customers.id', '=', 'debts.customer_id')
-            ->where('debts.status', '!=', 'paid') 
+            ->whereNotIn('debts.status', ['paid', 'united'])
             ->selectRaw(
                 'SUM(TIMESTAMPDIFF(MONTH, debts.start_date, debts.end_date) + IF(DAY(debts.end_date) >= DAY(debts.start_date), 1, 0)) as total_months'
             )
@@ -120,7 +120,7 @@ class DashboardController extends Controller
     {
         $debtBetweenTwelveAndThirtySixMonthsAll = Customer::select('customers.id', 'customers.name', 'customers.last_name')
             ->join('debts', 'customers.id', '=', 'debts.customer_id')
-            ->where('debts.status', '!=', 'paid') 
+            ->whereNotIn('debts.status', ['paid', 'united'])
             ->selectRaw(
                 'SUM(TIMESTAMPDIFF(MONTH, debts.start_date, debts.end_date) + IF(DAY(debts.end_date) >= DAY(debts.start_date), 1, 0)) as total_months'
             )
@@ -135,7 +135,7 @@ class DashboardController extends Controller
     {
         $debtBetweenOneAndElevenMonthsAll = Customer::select('customers.id', 'customers.name', 'customers.last_name')
         ->join('debts', 'customers.id', '=', 'debts.customer_id')
-        ->where('debts.status', '!=', 'paid')
+        ->whereNotIn('debts.status', ['paid', 'united'])
         ->selectRaw(
             'SUM(TIMESTAMPDIFF(MONTH, debts.start_date, debts.end_date) + IF(DAY(debts.end_date) >= DAY(debts.start_date), 1, 0)) as total_months'
         )

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -27,7 +27,7 @@ class PaymentController extends Controller
         if ($request->filled('period')) {
             $periodParts = explode('/', $request->period);
             $monthName = strtolower(trim($periodParts[0]));
-            $year = trim($periodParts[1]); // Year
+            $year = trim($periodParts[1]);
 
             $months = [
                 'enero' => 1,
@@ -59,7 +59,10 @@ class PaymentController extends Controller
         }
 
         $payments = $query->paginate(10);
-        $customers = Customer::all();
+        $customers = Customer::where('state', 1)
+                     ->orWhereNull('state')
+                     ->get();
+
 
         return view('payments.index', compact('payments', 'customers'));
     }
@@ -68,7 +71,7 @@ class PaymentController extends Controller
     {
         $customerId = $request->input('customer_id');
         $debts = Debt::where('customer_id', $customerId)
-            ->where('status', '!=', 'paid')
+            ->whereNotIn('status', ['paid', 'united'])
             ->orderBy('start_date', 'asc')
             ->get()
             ->map(function ($debt) {

--- a/database/migrations/2024_08_20_191329_create_debts_table.php
+++ b/database/migrations/2024_08_20_191329_create_debts_table.php
@@ -20,7 +20,7 @@ class CreateDebtsTable extends Migration
             $table->date('end_date');
             $table->decimal('amount', 10, 2);
             $table->decimal('debt_current', 8, 2)->default(0);
-            $table->enum('status', ['pending', 'partial', 'paid'])->default('pending');
+            $table->enum('status', ['pending', 'partial', 'paid','united'])->default('pending');
             $table->text('note')->nullable();
             $table->softDeletes();
         

--- a/database/seeders/CustomersTableSeeder.php
+++ b/database/seeders/CustomersTableSeeder.php
@@ -20,7 +20,7 @@ class CustomersTableSeeder extends Seeder
 
         $costIds = DB::table('costs')->pluck('id')->toArray();
 
-        foreach (range(1, 10) as $index) {
+        foreach (range(1, 30) as $index) {
             DB::table('customers')->insert([
                 'cost_id' => $faker->randomElement($costIds),
                 'name' => $faker->firstName,

--- a/resources/views/customers/edit.blade.php
+++ b/resources/views/customers/edit.blade.php
@@ -70,6 +70,7 @@
                                                 <option value="">Selecciona una opción</option>
                                                 <option value="Casado/a" {{ $customer->marital_status == "Casado/a" ? 'selected' : '' }}>Casado/a</option>
                                                 <option value="Soltero/a" {{ $customer->marital_status == "Soltero/a" ? 'selected' : '' }}>Soltero/a</option>
+                                                <option value="Divorciado/a" {{ $customer->marital_status == "Divorciado/a" ? 'selected' : '' }}>Viudo/a</option>
                                                 <option value="Viudo/a" {{ $customer->marital_status == "Viudo/a" ? 'selected' : '' }}>Viudo/a</option>
                                             </select>
                                         </div>

--- a/resources/views/debts/customerDebtsModal.blade.php
+++ b/resources/views/debts/customerDebtsModal.blade.php
@@ -1,0 +1,52 @@
+<div class="modal fade" id="consolidateDebts{{ $debt->customer->id }}" tabindex="-1" role="dialog" aria-labelledby="consolidateModalLabel{{ $debt->customer->id }}" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="card-success">
+                <div class="modal-header bg-success text-white">
+                    <h5 class="modal-title" id="consolidateModalLabel{{ $debt->customer->id }}">Consolidar Deudas del Usuario</h5>
+                    <button type="button" class="close text-white" onclick="closeCurrentModal('#consolidateDebts{{ $debt->customer->id}}')"  aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <form action="{{ route('debts.consolidate', $debt->customer->id) }}" method="POST">
+                    @csrf
+                    <input type="hidden" name="customer_id" value="{{ $debt->customer->id }}">
+                    <div class="modal-body">
+                        <div class="form-group row">
+                            <div class="col-md-6">
+                                <label>Fecha de Inicio</label>
+                                <input type="text" name="start_date" readonly class="form-control" id="consolidateStartDate{{ $debt->customer->id }}">
+                            </div>
+                            <div class="col-md-6">
+                                <label>Fecha de Fin</label>
+                                <input type="text" readonly name="end_date" class="form-control" id="consolidateEndDate{{ $debt->customer->id }}">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label>Monto Total</label>
+                            <input type="text" name="total_amount" readonly class="form-control" id="consolidateTotalAmount{{ $debt->customer->id }}">
+                        </div>
+
+                        <div class="col-lg-12">
+                            <div class="form-group">
+                                <label for="note" class="form-label">Observación</label>
+                                <textarea class="form-control" name="note" placeholder="Ingresa una observación">{{ old('note') }}</textarea>
+                            </div>
+                        </div>
+
+                        <div class="debt-list overflow-auto" style="max-height: 200px;">
+                            <h5>Deudas a Unir</h5>
+                            <ul id="debtList{{ $debt->customer->id }}" class="list-group small">
+                            </ul>
+                        </div>
+                        
+                    </div>
+                    <div class="modal-footer">
+                        <button type="submit" class="btn btn-primary">Confirmar Unión</button>
+                        <button type="button" class="btn btn-secondary" onclick="closeCurrentModal('#consolidateDebts{{ $debt->customer->id}}')" >Cerrar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/payments/create.blade.php
+++ b/resources/views/payments/create.blade.php
@@ -55,10 +55,10 @@
                                     </div>
                                     <div class="col-lg-6">
                                         <div class="form-group">
-                                            <label for="suggested_amount" class="form-label" style="font-weight: bold; color: #555;">Monto Sugerido a Pagar</label>
+                                            <label for="suggested_amount" class="form-label" style="font-weight: bold; color: #555;">Monto a Pagar</label>
                                             <div style="border-radius: 8px; background-color: #d2e0ca; padding: 10px; box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1); display: flex; align-items: center;">
                                                 <i class="fas fa-money-bill-wave" style="margin-right: 8px; color: #28a745;"></i>
-                                                <p id="suggested_amount" class="form-control-static" style="margin: 0; font-size: 16px; color: #333;">Selecciona una deuda para ver el monto sugerido.</p>
+                                                <p id="suggested_amount" class="form-control-static" style="margin: 0; font-size: 16px; color: #333;">Selecciona una deuda para ver el monto a pagar.</p>
                                             </div>
                                         </div>
                                     </div>                                                                       

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,4 +81,9 @@ Route::group(['middleware' => ['auth']], function () {
     Route::post('/profile/editImage', [ProfileController::class, 'updateImage'])->name('profile.update.image');
     Route::put('/profile/updatePassword', [ProfileController::class, 'updatePassword'])->name('profile.updatePassword');
 
+    Route::get('/debts/consolidate/{customer_id}', [DebtController::class, 'getPendingDebts'])->name('debts.getPendingDebts');
+    Route::post('/debts/consolidate/{customerId}', [DebtController::class, 'consolidate'])->name('debts.consolidate');
+
+
+
 });


### PR DESCRIPTION
A button was created to consolidate debts, which opens a modal for consolidation. In this modal, the start date, end date, and amount fields are already filled. Additionally, a note can be added manually. At the bottom, it disp

When the user clicks accept, the new debt is created, and the debts being consolidated are updated with the status "united." These debts are no longer shown in the list of debts, and only the new consolidated debt is

It was validated that payments must always be applied to the oldest debt

Corrections were made in all areas where the sum of debts is used, ensuring that debts with the status "united" are not included in the calculation.